### PR TITLE
raise an exception when input_ids are too large, prevent program from crashing.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -132,6 +132,9 @@ def generate_stream_chatglm3(model: PreTrainedModel, tokenizer: PreTrainedTokeni
     inputs = inputs.to(model.device)
     input_echo_len = len(inputs["input_ids"][0])
 
+    if input_echo_len >= model.config.seq_length:
+        raise
+
     eos_token_id = [
         tokenizer.eos_token_id,
         tokenizer.get_command("<|user|>"),


### PR DESCRIPTION
When hosting openai_api.py, crashing may occur when input_ids were larger than config.seq_length.

Potential reason for this is at huggingface/modeling_chatglm.py:823
~~~
rotary_pos_emb = rotary_pos_emb[position_ids]
~~~
And any upcoming shorter requests will be returned as `ERROR:    Exception in ASGI applicatio...`, which blocked the entire API.

Outputs:
~~~
INFO:     127.0.0.1:58728 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 408, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/fastapi/applications.py", line 289, in __call__
    await super().__call__(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/middleware/cors.py", line 83, in __call__
    await self.app(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/fastapi/routing.py", line 273, in app
    raw_response = await run_endpoint_function(
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/fastapi/routing.py", line 190, in run_endpoint_function
    return await dependant.call(**values)
  File "/root/autodl-tmp/Chatglm-playgorund/ChatGLM3/openai_api.py", line 152, in create_chat_completion
    response = generate_chatglm3(model, tokenizer, gen_params)
  File "/root/autodl-tmp/Chatglm-playgorund/ChatGLM3/utils.py", line 196, in generate_chatglm3
    for response in generate_stream_chatglm3(model, tokenizer, params):
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 35, in generator_context
    response = gen.send(None)
  File "/root/autodl-tmp/Chatglm-playgorund/ChatGLM3/utils.py", line 132, in generate_stream_chatglm3
    inputs = inputs.to(model.device)
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 772, in to
    self.data = {k: v.to(device=device) for k, v in self.data.items()}
  File "/root/miniconda3/envs/chatglm/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 772, in <dictcomp>
    self.data = {k: v.to(device=device) for k, v in self.data.items()}
RuntimeError: CUDA error: device-side assert triggered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
~~~

I tried to add length comparison before calling ChatGLMModel.forward(), prevent API from crashing.

