### PR TITLE
在Stream版本Demo的函数调用Message中添加function_call信息

### DIFF
--- a/tool_using/openai_api_demo.py
+++ b/tool_using/openai_api_demo.py
@@ -65,7 +65,8 @@ def run_conversation(query: str, stream=False, functions=None, max_retry=5):
                     params["messages"].append(
                         {
                             "role": "assistant",
-                            "content": output
+                            "content": output,
+                            "function_call": function_call
                         }
                     )
                     params["messages"].append(


### PR DESCRIPTION
我在基于这个demo实现多轮对话的tool-using agent，遇到API的`finish_reason`为`function_call`，但API response中不包含`function_call`这一项，推测是历史对话中的函数调用message缺失了`function_call`这一项，从而误导了后续的函数调用回答。

同时注意到32行的非Stream版本的demo中，函数调用的message包含了`function_call`信息。
https://github.com/THUDM/ChatGLM3/blob/cb7b166fd5a99ee07e3a6cebc0fa71384b4fea09/tool_using/openai_api_demo.py#L24-L33

为了与非Stream版本demo保持一致，同时为了避免对使用这个demo的用户造成可能的困惑，在Stream版本demo的函数调用消息中补充了`function_call`这一项信息。