### PR TITLE
Update requirements.txt, fix version number for installing gradio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ protobuf
 transformers==4.30.2
 cpm_kernels
 torch>=2.0
-gradio==3.39
+gradio==3.39.0
 mdtex2html
 sentencepiece
 accelerate


### PR DESCRIPTION

<img width="703" alt="image" src="https://github.com/THUDM/ChatGLM3/assets/5728396/bbd03153-695b-4553-8a47-d5b4d5b22ec9">

ERROR: Could not find a version that satisfies the requirement gradio==3.39 (from versions: none)
ERROR: No matching distribution found for gradio==3.39