### PR TITLE
bug fix: 微调代码的prompt构建存在问题

### DIFF
--- a/finetune_demo/preprocess_utils.py
+++ b/finetune_demo/preprocess_utils.py
@@ -39,7 +39,7 @@ def format_conversation(item, tokenizer, conversation_key: str, tool_key: str):
         conversations.insert(0, 
             {
                 "role": "system", 
-                "content": TOOL_DEFINITION_PREFIX + json.dumps(item[tool_key], ensure_ascii=False)
+                "content": TOOL_DEFINITION_PREFIX + json.dumps(item[tool_key], indent=4, ensure_ascii=False)
             }
         )
     


### PR DESCRIPTION
bug fix: 微调代码的prompt构建存在问题
![image](https://github.com/THUDM/ChatGLM3/assets/40080081/bf102e5a-057c-40b8-91e7-894a576e7eff)


chatglm模型代码里面，构造prompt的时候是带缩进的，但是微调代码在构建prompt的时候，没有缩进，这可能会导致训练和推理两个阶段存在gap