### PR TITLE
修改依赖和openai的api

### DIFF
--- a/composite_demo/tool_registry.py
+++ b/composite_demo/tool_registry.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+import copy
 import inspect
 from pprint import pformat
 import traceback
@@ -56,7 +56,7 @@ def dispatch_tool(tool_name: str, tool_params: dict) -> str:
     return str(ret)
 
 def get_tools() -> dict:
-    return deepcopy(_TOOL_DESCRIPTIONS)
+    return copy.deepcopy(_TOOL_DESCRIPTIONS)
 
 # Tool Definitions
 

--- a/openai_api_demo/requirements.txt
+++ b/openai_api_demo/requirements.txt
@@ -1,1 +1,2 @@
 openai>=1.3.0
+pydantic>=2.5.1

--- a/openai_api_demo/utils.py
+++ b/openai_api_demo/utils.py
@@ -107,12 +107,8 @@ def generate_stream_chatglm3(model: PreTrainedModel, tokenizer: PreTrainedTokeni
     temperature = float(params.get("temperature", 1.0))
     repetition_penalty = float(params.get("repetition_penalty", 1.0))
     top_p = float(params.get("top_p", 1.0))
-    max_new_tokens = int(params.get("max_tokens", None))
-    max_length = params.get("max_length", None)
-    # TODO 废弃max_length,使用max_new_tokens
-
+    max_new_tokens = int(params.get("max_tokens", 256))
     echo = params.get("echo", True)
-
     messages = process_chatglm_messages(messages, functions=functions)
     query, role = messages[-1]["content"], messages[-1]["role"]
 
@@ -123,14 +119,6 @@ def generate_stream_chatglm3(model: PreTrainedModel, tokenizer: PreTrainedTokeni
     if input_echo_len >= model.config.seq_length:
         print(f"Input length larger than {model.config.seq_length}")
 
-    # TODO 废弃max_length,使用max_new_tokens
-    if max_new_tokens is not None and max_length is not None:  # OpenAI接口的用户传入的应该是max_new_tokens才是适配OpenAI接口的。
-        max_length = None
-
-    if max_new_tokens is None and max_length is None:  # 什么参数都没传
-        max_new_tokens = 256
-        max_length = min(max_new_tokens + input_echo_len, model.config.seq_length)
-
     eos_token_id = [
         tokenizer.eos_token_id,
         tokenizer.get_command("<|user|>"),
@@ -138,7 +126,6 @@ def generate_stream_chatglm3(model: PreTrainedModel, tokenizer: PreTrainedTokeni
 
     gen_kwargs = {
         "max_new_tokens": max_new_tokens,
-        "max_length": max_length,
         "do_sample": True if temperature > 1e-5 else False,
         "top_p": top_p,
         "repetition_penalty": repetition_penalty,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,12 @@ protobuf
 transformers>=4.30.2
 cpm_kernels
 torch>=2.0
-gradio~=3.39
-mdtex2html
+gradio~=3.3.9
 sentencepiece
 accelerate
 sse-starlette
 streamlit>=1.24.0
 fastapi>=0.95.1
-uvicorn
+uvicorn~=0.24.0
 sse_starlette
-loguru
+loguru~=0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ accelerate
 sse-starlette
 streamlit>=1.24.0
 fastapi>=0.95.1
-typing_extensions
 uvicorn
 sse_starlette
 loguru


### PR DESCRIPTION
1. 去除OpenAI API demo中的max_length, 使用max_new_tokens，更符合OpenAI API格式
2. 更新了openai子文件夹依赖，将pydantic>=2.5.1，使用Pydantic3语法，并修改了部分代码
3. 删除了总依赖中的typing_extensions