### PR TITLE
更新依赖和windows下pt文件为None时寻找问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@ gradio~=3.39
 sentencepiece
 accelerate
 sse-starlette
-streamlit>=1.24.0
+streamlit>=1.29.0
 fastapi>=0.104.1
 uvicorn~=0.24.0
 loguru~=0.7.2
-latex2mathml
+mdtex2html>=1.2.0
+latex2mathml>=3.76.0


### PR DESCRIPTION
1. 依赖已经更新
2. PT文件为None时，加一层系统路径检查，只有检查路径存在并且PT文件不为none才执行（部分windows用户bug）