### PR TITLE
Fix Default Device Assignment for Model Loading When `pt_checkpoint` Exists

### DIFF
--- a/composite_demo/client.py
+++ b/composite_demo/client.py
@@ -128,7 +128,7 @@ class HFClient(Client):
 
         if pt_checkpoint is not None and os.path.exists(pt_checkpoint):
             config = AutoConfig.from_pretrained(model_path, trust_remote_code=True, pre_seq_len=PRE_SEQ_LEN)
-            self.model = AutoModel.from_pretrained(model_path, trust_remote_code=True, config=config)
+            self.model = AutoModel.from_pretrained(model_path, trust_remote_code=True, config=config, device_map="auto")
             prefix_state_dict = torch.load(os.path.join(pt_checkpoint, "pytorch_model.bin"))
             new_prefix_state_dict = {}
             for k, v in prefix_state_dict.items():


### PR DESCRIPTION
In the existing `composite_demo\client.py:HFClient()` implementation, a scenario occurs when `pt_checkpoint is not None` and `os.path.exists(pt_checkpoint)` is true, but the device is not explicitly set. This leads to the model being loaded onto the CPU by default. Consequently, this triggers a `RuntimeError: "addmm_impl_cpu_" not implemented for 'Half'`.

To resolve this issue, we can introduce a fix by setting `device_map` to `auto`. This change ensures that the model is automatically assigned to an appropriate device, avoiding the aforementioned runtime error.