### PR TITLE
fix: 修复 tools_using_demo 中 OpenAI API demo 无法成功调用 Function calling 的问题

### DIFF
--- a/tools_using_demo/openai_api_demo.py
+++ b/tools_using_demo/openai_api_demo.py
@@ -12,13 +12,13 @@ client = OpenAI(
   api_key = "xxx"
 )
 
-functions = get_tools()
+tools = get_tools()
 
 
-def run_conversation(query: str, stream=False, functions=None, max_retry=5):
+def run_conversation(query: str, stream=False, tools=None, max_retry=5):
     params = dict(model="chatglm3", messages=[{"role": "user", "content": query}], stream=stream)
-    if functions:
-        params["functions"] = functions
+    if tools:
+        params["tools"] = tools
     response = client.chat.completions.create(**params)
 
     for _ in range(max_retry):
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     logger.info("\n=========== next conversation ===========")
 
     query = "帮我查询北京的天气怎么样"
-    run_conversation(query, functions=functions, stream=True)
+    run_conversation(query, tools=tools, stream=True)


### PR DESCRIPTION
Pull #669后，openai_api_demo 中 openai_api.py 更新 Function calling 调用参数为 `tools`，导致 tools_using_demo 中 openai_api_demo.py 的 `params["functions"]` 失效。

修改说明: 
1. 上述问题通过修改 `params["functions"]` 为 `params["tools"]` 解决。
2. 为统一上下文变量名称和参数名称，修改变量名及参数名 `functions` 为 `tools` 。
 