### PR TITLE
fix: 修复 openai_api_demo 中的一些问题

### DIFF
--- a/openai_api_demo/api_server.py
+++ b/openai_api_demo/api_server.py
@@ -109,7 +109,7 @@ class DeltaMessage(BaseModel):
 
 ## for Embedding
 class EmbeddingRequest(BaseModel):
-    input: List[str]
+    input: List[str] | str
     model: str
 
 
@@ -174,6 +174,8 @@ async def health() -> Response:
 
 @app.post("/v1/embeddings", response_model=EmbeddingResponse)
 async def get_embeddings(request: EmbeddingRequest):
+    if isinstance(request.input, str):
+        request.input = [request.input]
     embeddings = [embedding_model.encode(text) for text in request.input]
     embeddings = [embedding.tolist() for embedding in embeddings]
 

--- a/openai_api_demo/api_server.py
+++ b/openai_api_demo/api_server.py
@@ -307,6 +307,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
     if isinstance(function_call, dict):
         finish_reason = "function_call"
         function_call = FunctionCallResponse(**function_call)
+        response["text"]=response["text"].split("<|assistant|>")[0]
 
     message = ChatMessage(
         role="assistant",


### PR DESCRIPTION
- [修复 openai_api_demo 中当大模型试图生成带工具调用的回答时报错的问题](https://github.com/THUDM/ChatGLM3/commit/2afdbb9384087f682514e438fd91e577e51513d6)
   - 似乎在一些情况下，ChatGLM 会试图生成同时包含正常回答和工具调用的响应（如 [`PROMPT.md`](https://github.com/THUDM/ChatGLM3/blob/main/PROMPT.md) 中的这个示例），而这时当前版本的代码会在处理 GLM 响应时报错，无法生成正确响应，这个 PR 给出了一个简单的处理（有一些不确定的地方在下面的 `comments` 中给出了）
````
<|assistant|>
好的，让我们来查看今天的天气
<|assistant|>get_current_weather
```python
tool_call(location="beijing", unit="celsius")
```
````
- [修复 openai_api_demo 中 EmbeddingRequest 参数 input 为单一字符串时的报错问题](https://github.com/THUDM/ChatGLM3/commit/330dff6399ef19c8fa6c732ede40504dce9c5f4c)
   - 当前版本的代码中 `/v1/embeddings` API 只接收 `List[str]` 类型的 input 参数，而当输入字符串只有一个时，OpenAI API 实际上也接收 `str` 类型的参数（这也是 `LangChain` 等框架的默认行为），而当前版本代码遇到这种情况会直接报 `422`，这个 PR 给出了一个简单的处理