### PR TITLE
临时锁定transformers版本

### DIFF
--- a/finetune_demo/configs/ptuning_v2.yaml
+++ b/finetune_demo/configs/ptuning_v2.yaml
@@ -36,4 +36,5 @@ training_args:
   #deepspeed: ds_zero_3.json
 peft_config:
   peft_type: PREFIX_TUNING
+  task_type: CAUSAL_LM
   num_virtual_tokens: 64

--- a/finetune_demo/requirements.txt
+++ b/finetune_demo/requirements.txt
@@ -3,5 +3,6 @@ ruamel_yaml>=0.18.5
 rouge_chinese>=1.0.3
 jupyter>=1.0.0
 datasets>=2.16.1
-peft>=0.8.1
+peft==0.7.1
+transformers==4.36.2
 deepspeed>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # basic requirements
 
 protobuf>=4.25.2
-transformers>=4.37.2
+transformers==4.36.2
 tokenizers>=0.15.0
 cpm_kernels>=1.0.11
 torch>=2.1.0


### PR DESCRIPTION
微调模型先不要升级到4.37和peft 0.8