### PR TITLE
fix finetune_hf.py for finetuning

### DIFF
--- a/finetune_demo/finetune_hf.py
+++ b/finetune_demo/finetune_hf.py
@@ -501,6 +501,7 @@ def main(
         tokenizer.get_command('<|observation|>'),
     ]
     model.gradient_checkpointing_enable()
+    model.enable_input_require_grads()
     trainer = Seq2SeqTrainer(
         model=model,
         args=ft_config.training_args,


### PR DESCRIPTION
Enables the gradients for the input embeddings. Fix the following error message: 'RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn'