### PR TITLE
修复工具调用结束后，角色未从observation恢复为user的bug

### DIFF
--- a/tools_using_demo/cli_demo_tool.py
+++ b/tools_using_demo/cli_demo_tool.py
@@ -70,6 +70,8 @@ def main():
         print("")
         if isinstance(response, dict):
             role = "observation"
+        else:
+            role = "user"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
![image](https://github.com/THUDM/ChatGLM3/assets/73787075/bea2ef9d-dd0b-4dfc-b07d-0ec51b9c5de8)

工具调用结束后，角色应从observation恢复为user。更正了此处的逻辑。

After the tool invocation ends, the role should revert from observation to user. Corrected logic here.