### PR TITLE
解决langchain_demo一轮对话中无法支持多轮tool_call调用的问题; 以及优化参数定义

### DIFF
--- a/langchain_demo/ChatGLM3.py
+++ b/langchain_demo/ChatGLM3.py
@@ -124,7 +124,9 @@ Action:
 {json.dumps(final_answer_json, ensure_ascii=False)}
 ```"""
 
-    def _call(self, prompt: str, history: List = [], stop: Optional[List[str]] = ["<|user|>"]):
+    def _call(self, prompt: str, history: List = None, stop: Optional[List[str]] = ["<|user|>"]):
+        if not history:
+            history = []
         if not self.has_search:
             self.history, query = self._tool_history(prompt)
         else:

--- a/langchain_demo/ChatGLM3.py
+++ b/langchain_demo/ChatGLM3.py
@@ -93,7 +93,7 @@ class ChatGLM3(LLM):
 
             lines = content.split('\n')
             for line in lines:
-                if 'tool_call(' in line and ')' in line and self.has_search is False:
+                if 'tool_call(' in line and ')' in line:
                     # 获取括号内的字符串
                     params_str = line.split('tool_call(')[-1].split(')')[0]
 


### PR DESCRIPTION
1. langchain_demo中的ChatGLM3实现无法支持一轮对话中的多轮tool_call调用。
第一次能正常进行tool_call解析和调用，第二次则直接返回```python\ntool_call(param='param')```。
原因是_extract_tool函数运行过程中，第一次解析tool_call调用后将self.has_search设置成了True，导致第二次无法进入tool_call的解析。
2. 优化history参数定义。