### PR TITLE
Add RAGFlow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Intel 开发的高性能 CPU 和 GPU 加速推理方案，可以参考此 [步�
 
 * [BISHENG](https://github.com/dataelement/bisheng): 开源大模型应用开发平台,赋能和加速大模型应用开发落地，帮助用户以最佳体验进入下一代应用开发模式。
 
+* [RAGFlow](https://github.com/infiniflow/ragflow): RAGFlow 是一款基于深度文档理解构建的开源 RAG（Retrieval-Augmented Generation）引擎。可为各种规模的企业及个人提供一套精简的 RAG 工作流程，结合大语言模型（LLM）针对用户各类不同的复杂格式数据提供可靠的问答以及有理有据的引用。
+
 ## 评测结果
 
 ### 典型任务

--- a/README_en.md
+++ b/README_en.md
@@ -74,6 +74,8 @@ Application framework:
 * [LangChain-Chatchat](https://github.com/chatchat-space/Langchain-Chatchat): Based on large language models such as ChatGLM and application frameworks such as Langchain, open source and offline deployable retrieval enhancement generation (RAG) large Model knowledge base project.
 
 * [BISHENG](https://github.com/dataelement/bisheng): open-source platform for developing LLM applications. It empowers and accelerates the development of LLM applications and helps users to enter the next generation of application development mode with the best experience.
+
+* [RAGFlow](https://github.com/infiniflow/ragflow): An open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. It offers a streamlined RAG workflow for businesses of any scale, combining LLM (Large Language Models) to provide truthful question-answering capabilities, backed by well-founded citations from various complex formatted data.
 ## Evaluation Results
 
 ### Typical Tasks


### PR DESCRIPTION
At very beginning, RAGFlow supported ZHIPU as the model provider and ChatGLM in local deployment. I would like to add one more RAGFlow in ChatGLM readme.