### PR TITLE
Bugfix：修复 Deepspeed 运算结果有误的问题

### DIFF
--- a/finetune_demo/requirements.txt
+++ b/finetune_demo/requirements.txt
@@ -4,5 +4,5 @@ rouge_chinese>=1.0.3
 jupyter>=1.0.0
 datasets>=2.18.0
 peft>=0.10.0
-deepspeed==0.13.1
+deepspeed==0.16.2
 mpi4py>=3.1.5


### PR DESCRIPTION
solve #1344 

经过排查，最终发现代码等号依赖了一个有问题的 Deepspeed 版本 0.13.1：使用 [validate_zero](https://github.com/tohtana/validate_zero) 工具对 ChatGLM3 依赖环境的 Deepspeed 0.13.1 进行测试，发现计算结果存在问题。将 Deepspeed 版本更新至 0.16.2，能够解决问题。

注：Deepspeed 有关旧版本计算结果不一致情况的 issue：https://github.com/microsoft/DeepSpeed/issues/4815
